### PR TITLE
Remove dead code

### DIFF
--- a/src/Comparable.php
+++ b/src/Comparable.php
@@ -80,8 +80,6 @@ trait Comparable
             return $compared instanceof $comparable;
         };
 
-        $comparables = is_iterable($comparables) ? $comparables : [$comparables];
-
         foreach ($comparables as $key => $comparable) {
             if ($result = $callback($this, $comparable, $key)) {
                 return $returnKey ? $key : $result;


### PR DESCRIPTION
Due to `iterable` enforced type hint, `is_iterable` is always `true`.

So it either can get rid of this line or of the type hint so a class as can actually be passed as `string` for instance.